### PR TITLE
Split Styles and Font Icons Into Two Files

### DIFF
--- a/css/font.css
+++ b/css/font.css
@@ -1,0 +1,20 @@
+@font-face {
+	font-family: 'fontello';
+	src: url('../font/fontello.eot?78492063');
+	src: url('../font/fontello.eot?78492063#iefix') format('embedded-opentype'),
+		 url('../font/fontello.woff?78492063') format('woff'),
+		 url('../font/fontello.ttf?78492063') format('truetype'),
+		 url('../font/fontello.svg?78492063#fontello') format('svg');
+	font-weight: normal;
+	font-style: normal;
+}
+/* Chrome hack: SVG is rendered more smooth in Windozze. 100% magic, uncomment if you need it. */
+/* Note, that will break hinting! In other OS-es font will be not as sharp as it could be */
+/*
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  @font-face {
+	font-family: 'fontello';
+	src: url('../font/fontello.svg?11995952#fontello') format('svg');
+  }
+}
+*/

--- a/css/style.css
+++ b/css/style.css
@@ -1,24 +1,3 @@
-@font-face {
-	font-family: 'fontello';
-	src: url('../font/fontello.eot?78492063');
-	src: url('../font/fontello.eot?78492063#iefix') format('embedded-opentype'),
-       url('../font/fontello.woff?78492063') format('woff'),
-       url('../font/fontello.ttf?78492063') format('truetype'),
-       url('../font/fontello.svg?78492063#fontello') format('svg');
-    font-weight: normal;
-	font-style: normal;
-}
-/* Chrome hack: SVG is rendered more smooth in Windozze. 100% magic, uncomment if you need it. */
-/* Note, that will break hinting! In other OS-es font will be not as sharp as it could be */
-/*
-@media screen and (-webkit-min-device-pixel-ratio:0) {
-  @font-face {
-    font-family: 'fontello';
-    src: url('../font/fontello.svg?11995952#fontello') format('svg');
-  }
-}
-*/
-
 .simple-social-icons {
 	overflow: hidden;
 }

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -284,7 +284,9 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	}
 
 	function enqueue_css() {
-		wp_enqueue_style( 'simple-social-icons-font', plugin_dir_url( __FILE__ ) . 'css/style.css', array(), '1.0.5' );
+		$css_uri = plugin_dir_url( __FILE__ ) . 'css/';
+		wp_enqueue_style( 'simple-social-icons-font', $css_uri . 'font.css', array(), '1.0.0' );
+		wp_enqueue_style( 'simple-social-icons-style', $css_uri . 'style.css', array(), '1.0.6' );
 	}
 
 	/**


### PR DESCRIPTION
Currently, because the font icons and styles are contained within the same stylesheet, if someone wants to customize the look of the widget they need to use !important declarations and very aggressive selectors. If you were to split these into two files, it would add an extra http request but it also would allow for much more flexibility. 

With these decoupled, developers can now de-register the styles and unhook the function that outputs styling in wp_head. All the icons and the cool widget, none of the default styles.