### PR TITLE
Accessibility improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Contributors:
 * [Nathan Rice](https://github.com/nathanrice)
 * [StudioPress](https://github.com/studiopress)
 * [Brian Gardner](https://github.com/bgardner)
+* [Shannon Hale](https://github.com/shannonsans)
 
 ### Description
 
@@ -103,3 +104,9 @@ NOTE - The rights to each pictogram in the social extension are either trademark
 
 1.0.12
 * Prevent ModSecurity blocking fonts from loading
+
+1.0.13
+* Add textdomain loader
+
+1.0.14
+* Accessibility improvements: change icon color on focus as well as on hover, add text description for assistive technologies

--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,6 @@
 	font-variant: normal !important;
 	font-weight: normal !important;
 	line-height: 1em;
-	speak: none;
 	text-align: center;
 	text-decoration: none !important;
 	text-transform: none !important;
@@ -54,4 +53,15 @@
 .simple-social-icons ul.aligncenter li {
 	display: inline-block;
 	float: none;
+}
+
+.simple-social-icons .sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	border: 0;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -55,7 +55,7 @@
 	float: none;
 }
 
-.simple-social-icons .sr-only {
+.simple-social-icons .screen-reader-text {
 	position: absolute;
 	width: 1px;
 	height: 1px;

--- a/languages/simple-social-icons.pot
+++ b/languages/simple-social-icons.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2.0 (or later).
 msgid ""
 msgstr ""
-"Project-Id-Version: Simple Social Icons 1.0.9\n"
+"Project-Id-Version: Simple Social Icons 1.0.14\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2015-09-29 22:00:46+00:00\n"
+"POT-Creation-Date: 2015-10-26 23:48:14+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,71 +24,135 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Textdomain-Support: yes\n"
 
-#: simple-social-icons.php:113
+#: simple-social-icons.php:124
 msgid "Bloglovin URI"
 msgstr ""
 
-#: simple-social-icons.php:117
+#: simple-social-icons.php:125
+msgid "Bloglovin"
+msgstr ""
+
+#: simple-social-icons.php:128
 msgid "Dribbble URI"
 msgstr ""
 
-#: simple-social-icons.php:121
+#: simple-social-icons.php:129
+msgid "Dribbble"
+msgstr ""
+
+#: simple-social-icons.php:132
 msgid "Email URI"
 msgstr ""
 
-#: simple-social-icons.php:125
+#: simple-social-icons.php:133
+msgid "Email"
+msgstr ""
+
+#: simple-social-icons.php:136
 msgid "Facebook URI"
 msgstr ""
 
-#: simple-social-icons.php:129
+#: simple-social-icons.php:137
+msgid "Facebook"
+msgstr ""
+
+#: simple-social-icons.php:140
 msgid "Flickr URI"
 msgstr ""
 
-#: simple-social-icons.php:133
+#: simple-social-icons.php:141
+msgid "Flickr"
+msgstr ""
+
+#: simple-social-icons.php:144
 msgid "GitHub URI"
 msgstr ""
 
-#: simple-social-icons.php:137
+#: simple-social-icons.php:145
+msgid "GitHub"
+msgstr ""
+
+#: simple-social-icons.php:148
 msgid "Google+ URI"
 msgstr ""
 
-#: simple-social-icons.php:141
+#: simple-social-icons.php:149
+msgid "Google+"
+msgstr ""
+
+#: simple-social-icons.php:152
 msgid "Instagram URI"
 msgstr ""
 
-#: simple-social-icons.php:145
+#: simple-social-icons.php:153
+msgid "Instagram"
+msgstr ""
+
+#: simple-social-icons.php:156
 msgid "Linkedin URI"
 msgstr ""
 
-#: simple-social-icons.php:149
+#: simple-social-icons.php:157
+msgid "Linkedin"
+msgstr ""
+
+#: simple-social-icons.php:160
 msgid "Pinterest URI"
 msgstr ""
 
-#: simple-social-icons.php:153
+#: simple-social-icons.php:161
+msgid "Pinterest"
+msgstr ""
+
+#: simple-social-icons.php:164
 msgid "RSS URI"
 msgstr ""
 
-#: simple-social-icons.php:157
+#: simple-social-icons.php:165
+msgid "RSS"
+msgstr ""
+
+#: simple-social-icons.php:168
 msgid "StumbleUpon URI"
 msgstr ""
 
-#: simple-social-icons.php:161
+#: simple-social-icons.php:169
+msgid "StumbleUpon"
+msgstr ""
+
+#: simple-social-icons.php:172
 msgid "Tumblr URI"
 msgstr ""
 
-#: simple-social-icons.php:165
+#: simple-social-icons.php:173
+msgid "Tumblr"
+msgstr ""
+
+#: simple-social-icons.php:176
 msgid "Twitter URI"
 msgstr ""
 
-#: simple-social-icons.php:169
-msgid "Vimeo URI"
-msgstr ""
-
-#: simple-social-icons.php:173
-msgid "YouTube URI"
+#: simple-social-icons.php:177
+msgid "Twitter"
 msgstr ""
 
 #: simple-social-icons.php:180
+msgid "Vimeo URI"
+msgstr ""
+
+#: simple-social-icons.php:181
+msgid "Vimeo"
+msgstr ""
+
+#: simple-social-icons.php:184
+msgid "YouTube URI"
+msgstr ""
+
+#: simple-social-icons.php:185
+msgid "YouTube"
+msgstr ""
+
+#: simple-social-icons.php:191
 msgid "Displays select social icons."
 msgstr ""
 
@@ -96,63 +160,63 @@ msgstr ""
 msgid "Simple Social Icons"
 msgstr ""
 
-#: simple-social-icons.php:265
+#: simple-social-icons.php:276
 msgid "Title:"
 msgstr ""
 
-#: simple-social-icons.php:267
+#: simple-social-icons.php:278
 msgid "Open links in new window?"
 msgstr ""
 
-#: simple-social-icons.php:269
+#: simple-social-icons.php:280
 msgid "Icon Size"
 msgstr ""
 
-#: simple-social-icons.php:271
+#: simple-social-icons.php:282
 msgid "Icon Border Radius:"
 msgstr ""
 
-#: simple-social-icons.php:273
+#: simple-social-icons.php:284
 msgid "Border Width:"
 msgstr ""
 
-#: simple-social-icons.php:276
+#: simple-social-icons.php:287
 msgid "Alignment"
 msgstr ""
 
-#: simple-social-icons.php:278
+#: simple-social-icons.php:289
 msgid "Align Left"
 msgstr ""
 
-#: simple-social-icons.php:279
+#: simple-social-icons.php:290
 msgid "Align Center"
 msgstr ""
 
-#: simple-social-icons.php:280
+#: simple-social-icons.php:291
 msgid "Align Right"
 msgstr ""
 
-#: simple-social-icons.php:286
+#: simple-social-icons.php:297
 msgid "Icon Font Color:"
 msgstr ""
 
-#: simple-social-icons.php:288
+#: simple-social-icons.php:299
 msgid "Icon Font Hover Color:"
 msgstr ""
 
-#: simple-social-icons.php:290
+#: simple-social-icons.php:301
 msgid "Background Color:"
 msgstr ""
 
-#: simple-social-icons.php:292
+#: simple-social-icons.php:303
 msgid "Background Hover Color:"
 msgstr ""
 
-#: simple-social-icons.php:294
+#: simple-social-icons.php:305
 msgid "Border Color:"
 msgstr ""
 
-#: simple-social-icons.php:296
+#: simple-social-icons.php:307
 msgid "Border Hover Color:"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: nathanrice, studiopress, bgardner
+Contributors: nathanrice, studiopress, bgardner, shannonsans
 Tags: social media, social networking, social profiles
 Requires at least: 4.0
 Tested up to: 4.3.1
@@ -46,6 +46,9 @@ No, not at this time.
 NOTE - The rights to each pictogram in the social extension are either trademarked or copyrighted by the respective company. Icons that are included in the social extension can be identified at http://www.entypo.com/.
 
 == Changelog ==
+
+= 1.0.14 =
+* Accessibility improvements: change icon color on focus as well as on hover, add text description for assistive technologies
 
 = 1.0.13 =
 * Add textdomain loader

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -6,7 +6,7 @@ Description: A simple, CSS and icon font driven social icons widget.
 Author: Nathan Rice
 Author URI: http://www.nathanrice.net/
 
-Version: 1.0.13
+Version: 1.0.14
 
 Text Domain: simple-social-icons
 Domain Path: /languages
@@ -122,67 +122,67 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		$this->profiles = apply_filters( 'simple_social_default_profiles', array(
 			'bloglovin' => array(
 				'label'   => __( 'Bloglovin URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-bloglovin"><a href="%s" %s>' . $this->glyphs['bloglovin'] . '</a></li>',
+				'pattern' => '<li class="social-bloglovin"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['bloglovin'] . '</span><span class="sr-only">' . __( 'Bloglovin', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'dribbble' => array(
 				'label'   => __( 'Dribbble URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-dribbble"><a href="%s" %s>' . $this->glyphs['dribbble'] . '</a></li>',
+				'pattern' => '<li class="social-dribbble"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['dribbble'] . '</span><span class="sr-only">' . __( 'Dribbble', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'email' => array(
 				'label'   => __( 'Email URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-email"><a href="%s" %s>' . $this->glyphs['email'] . '</a></li>',
+				'pattern' => '<li class="social-email"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['email'] . '</span><span class="sr-only">' . __( 'Email', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'facebook' => array(
 				'label'   => __( 'Facebook URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-facebook"><a href="%s" %s>' . $this->glyphs['facebook'] . '</a></li>',
+				'pattern' => '<li class="social-facebook"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['facebook'] . '</span><span class="sr-only">' . __( 'Facebook', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'flickr' => array(
 				'label'   => __( 'Flickr URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-flickr"><a href="%s" %s>' . $this->glyphs['flickr'] . '</a></li>',
+				'pattern' => '<li class="social-flickr"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['flickr'] . '</span><span class="sr-only">' . __( 'Flickr', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'github' => array(
 				'label'   => __( 'GitHub URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-github"><a href="%s" %s>' . $this->glyphs['github'] . '</a></li>',
+				'pattern' => '<li class="social-github"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['github'] . '</span><span class="sr-only">' . __( 'GitHub', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'gplus' => array(
 				'label'   => __( 'Google+ URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-gplus"><a href="%s" %s>' . $this->glyphs['gplus'] . '</a></li>',
+				'pattern' => '<li class="social-gplus"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['gplus'] . '</span><span class="sr-only">' . __( 'Google+', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'instagram' => array(
 				'label'   => __( 'Instagram URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-instagram"><a href="%s" %s>' . $this->glyphs['instagram'] . '</a></li>',
+				'pattern' => '<li class="social-instagram"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['instagram'] . '</span><span class="sr-only">' . __( 'Instagram', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'linkedin' => array(
 				'label'   => __( 'Linkedin URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-linkedin"><a href="%s" %s>' . $this->glyphs['linkedin'] . '</a></li>',
+				'pattern' => '<li class="social-linkedin"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['linkedin'] . '</span><span class="sr-only">' . __( 'Linkedin', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'pinterest' => array(
 				'label'   => __( 'Pinterest URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-pinterest"><a href="%s" %s>' . $this->glyphs['pinterest'] . '</a></li>',
+				'pattern' => '<li class="social-pinterest"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['pinterest'] . '</span><span class="sr-only">' . __( 'Pinterest', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'rss' => array(
 				'label'   => __( 'RSS URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-rss"><a href="%s" %s>' . $this->glyphs['rss'] . '</a></li>',
+				'pattern' => '<li class="social-rss"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['rss'] . '</span><span class="sr-only">' . __( 'RSS', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'stumbleupon' => array(
 				'label'   => __( 'StumbleUpon URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-stumbleupon"><a href="%s" %s>' . $this->glyphs['stumbleupon'] . '</a></li>',
+				'pattern' => '<li class="social-stumbleupon"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['stumbleupon'] . '</span><span class="sr-only">' . __( 'StumbleUpon', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'tumblr' => array(
 				'label'   => __( 'Tumblr URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-tumblr"><a href="%s" %s>' . $this->glyphs['tumblr'] . '</a></li>',
+				'pattern' => '<li class="social-tumblr"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['tumblr'] . '</span><span class="sr-only">' . __( 'Tumblr', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'twitter' => array(
 				'label'   => __( 'Twitter URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-twitter"><a href="%s" %s>' . $this->glyphs['twitter'] . '</a></li>',
+				'pattern' => '<li class="social-twitter"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['twitter'] . '</span><span class="sr-only">' . __( 'Twitter', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'vimeo' => array(
 				'label'   => __( 'Vimeo URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-vimeo"><a href="%s" %s>' . $this->glyphs['vimeo'] . '</a></li>',
+				'pattern' => '<li class="social-vimeo"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['vimeo'] . '</span><span class="sr-only">' . __( 'Vimeo', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'youtube' => array(
 				'label'   => __( 'YouTube URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-youtube"><a href="%s" %s>' . $this->glyphs['youtube'] . '</a></li>',
+				'pattern' => '<li class="social-youtube"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['youtube'] . '</span><span class="sr-only">' . __( 'YouTube', 'simple-social-icons' ) . '</span></a></li>',
 			),
 		) );
 
@@ -425,7 +425,8 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		/** The CSS to output */
 		$css = '
 		.simple-social-icons ul li a,
-		.simple-social-icons ul li a:hover {
+		.simple-social-icons ul li a:hover,
+		.simple-social-icons ul li a:focus {
 			background-color: ' . $instance['background_color'] . ' !important;
 			border-radius: ' . $instance['border_radius'] . 'px;
 			color: ' . $instance['icon_color'] . ' !important;
@@ -434,10 +435,15 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 			padding: ' . $icon_padding . 'px;
 		}
 
-		.simple-social-icons ul li a:hover {
+		.simple-social-icons ul li a:hover,
+		.simple-social-icons ul li a:focus {
 			background-color: ' . $instance['background_color_hover'] . ' !important;
 			border-color: ' . $instance['border_color_hover'] . ' !important;
 			color: ' . $instance['icon_color_hover'] . ' !important;
+		}
+
+		.simple-social-icons ul li a:focus {
+			outline: 1px dotted ' . $instance['background_color_hover'] . ' !important;
 		}';
 
 		/** Minify a bit */

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -122,67 +122,67 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		$this->profiles = apply_filters( 'simple_social_default_profiles', array(
 			'bloglovin' => array(
 				'label'   => __( 'Bloglovin URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-bloglovin"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['bloglovin'] . '</span><span class="sr-only">' . __( 'Bloglovin', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-bloglovin"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['bloglovin'] . '</span><span class="screen-reader-text">' . __( 'Bloglovin', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'dribbble' => array(
 				'label'   => __( 'Dribbble URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-dribbble"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['dribbble'] . '</span><span class="sr-only">' . __( 'Dribbble', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-dribbble"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['dribbble'] . '</span><span class="screen-reader-text">' . __( 'Dribbble', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'email' => array(
 				'label'   => __( 'Email URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-email"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['email'] . '</span><span class="sr-only">' . __( 'Email', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-email"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['email'] . '</span><span class="screen-reader-text">' . __( 'Email', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'facebook' => array(
 				'label'   => __( 'Facebook URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-facebook"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['facebook'] . '</span><span class="sr-only">' . __( 'Facebook', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-facebook"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['facebook'] . '</span><span class="screen-reader-text">' . __( 'Facebook', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'flickr' => array(
 				'label'   => __( 'Flickr URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-flickr"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['flickr'] . '</span><span class="sr-only">' . __( 'Flickr', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-flickr"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['flickr'] . '</span><span class="screen-reader-text">' . __( 'Flickr', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'github' => array(
 				'label'   => __( 'GitHub URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-github"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['github'] . '</span><span class="sr-only">' . __( 'GitHub', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-github"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['github'] . '</span><span class="screen-reader-text">' . __( 'GitHub', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'gplus' => array(
 				'label'   => __( 'Google+ URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-gplus"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['gplus'] . '</span><span class="sr-only">' . __( 'Google+', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-gplus"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['gplus'] . '</span><span class="screen-reader-text">' . __( 'Google+', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'instagram' => array(
 				'label'   => __( 'Instagram URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-instagram"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['instagram'] . '</span><span class="sr-only">' . __( 'Instagram', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-instagram"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['instagram'] . '</span><span class="screen-reader-text">' . __( 'Instagram', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'linkedin' => array(
 				'label'   => __( 'Linkedin URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-linkedin"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['linkedin'] . '</span><span class="sr-only">' . __( 'Linkedin', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-linkedin"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['linkedin'] . '</span><span class="screen-reader-text">' . __( 'Linkedin', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'pinterest' => array(
 				'label'   => __( 'Pinterest URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-pinterest"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['pinterest'] . '</span><span class="sr-only">' . __( 'Pinterest', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-pinterest"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['pinterest'] . '</span><span class="screen-reader-text">' . __( 'Pinterest', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'rss' => array(
 				'label'   => __( 'RSS URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-rss"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['rss'] . '</span><span class="sr-only">' . __( 'RSS', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-rss"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['rss'] . '</span><span class="screen-reader-text">' . __( 'RSS', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'stumbleupon' => array(
 				'label'   => __( 'StumbleUpon URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-stumbleupon"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['stumbleupon'] . '</span><span class="sr-only">' . __( 'StumbleUpon', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-stumbleupon"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['stumbleupon'] . '</span><span class="screen-reader-text">' . __( 'StumbleUpon', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'tumblr' => array(
 				'label'   => __( 'Tumblr URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-tumblr"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['tumblr'] . '</span><span class="sr-only">' . __( 'Tumblr', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-tumblr"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['tumblr'] . '</span><span class="screen-reader-text">' . __( 'Tumblr', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'twitter' => array(
 				'label'   => __( 'Twitter URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-twitter"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['twitter'] . '</span><span class="sr-only">' . __( 'Twitter', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-twitter"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['twitter'] . '</span><span class="screen-reader-text">' . __( 'Twitter', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'vimeo' => array(
 				'label'   => __( 'Vimeo URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-vimeo"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['vimeo'] . '</span><span class="sr-only">' . __( 'Vimeo', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-vimeo"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['vimeo'] . '</span><span class="screen-reader-text">' . __( 'Vimeo', 'simple-social-icons' ) . '</span></a></li>',
 			),
 			'youtube' => array(
 				'label'   => __( 'YouTube URI', 'simple-social-icons' ),
-				'pattern' => '<li class="social-youtube"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['youtube'] . '</span><span class="sr-only">' . __( 'YouTube', 'simple-social-icons' ) . '</span></a></li>',
+				'pattern' => '<li class="social-youtube"><a href="%s" %s><span aria-hidden="true">' . $this->glyphs['youtube'] . '</span><span class="screen-reader-text">' . __( 'YouTube', 'simple-social-icons' ) . '</span></a></li>',
 			),
 		) );
 


### PR DESCRIPTION
Addresses the following:

1. Add `a:focus` to all link styles that appeared on `a:hover`. This allows viewers who navigate the page using a keyboard (instead of a mouse) to see where they are when they tab to the social links.
2. Adds outline styling to the icon links on `a:focus`, but not on `a:hover`. This addition to the `a:focus` is because color shouldn't be used alone to indicate a change. (On hover, the mouse cursor changes and this is enough.)
3. Wrap the icon font in a `<span aria-hidden="true" />` tag so screen readers don't announce it. (Using speak:none on the `<a>` tag doesn't work because a link is always announced, so removed that.)
4. Add a `<span class="sr-only" />` tag around a plain text description of the icon, and include this in the links. The `.sr-only` class hides the text from sighted users but gives assistive technology a label to announce. Without this, a screen reader just announces "Link." each time it reaches an icon -- it doesn't know where the link is going. With the new span, the screen reader announces "Link: Linkedin."

Here's a brief video demonstrating the changes: https://youtu.be/mmHJZ5LBAVQ