### PR TITLE
Change stylesheet filter hook name

### DIFF
--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -400,7 +400,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 
 	function enqueue_css() {
 
-		$cssfile	= apply_filters( 'simple_social_default_css', plugin_dir_url( __FILE__ ) . 'css/style.css' );
+		$cssfile = apply_filters( 'simple_social_default_stylesheet', plugin_dir_url( __FILE__ ) . 'css/style.css' );
 
 		wp_enqueue_style( 'simple-social-icons-font', esc_url( $cssfile ), array(), '1.0.12', 'all' );
 


### PR DESCRIPTION
Improve backwards compatibility by deprecating the original
simple_social_default_css filter. Fixes issue #30.