### PR TITLE
Give each icon title a unique ID

### DIFF
--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -106,91 +106,91 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		$this->profiles = apply_filters( 'simple_social_default_profiles', array(
 			'behance' => array(
 				'label'   => __( 'Behance URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-behance"><a href="%s" %s><svg role="img" class="social-behance" aria-labelledby="social-behance"><title id="social-behance">' . __( 'Behance', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-behance' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'behance', __( 'Behance', 'simple-social-icons' ) ),
 			),
 			'bloglovin' => array(
 				'label'   => __( 'Bloglovin URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-bloglovin"><a href="%s" %s><svg role="img" class="social-bloglovin" aria-labelledby="social-bloglovin"><title id="social-bloglovin">' . __( 'Bloglovin', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-bloglovin' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'bloglovin', __( 'Bloglovin', 'simple-social-icons' ) ),
 			),
 			'dribbble' => array(
 				'label'   => __( 'Dribbble URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-dribbble"><a href="%s" %s><svg role="img" class="social-dribbble" aria-labelledby="social-dribbble"><title id="social-dribbble">' . __( 'Dribbble', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-dribbble' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'dribbble', __( 'Dribbble', 'simple-social-icons' ) ),
 			),
 			'email' => array(
 				'label'   => __( 'Email URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-email"><a href="%s" %s><svg role="img" class="social-email" aria-labelledby="social-email"><title id="social-email">' . __( 'Email', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-email' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'email', __( 'Email', 'simple-social-icons' ) ),
 			),
 			'facebook' => array(
 				'label'   => __( 'Facebook URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-facebook"><a href="%s" %s><svg role="img" class="social-facebook" aria-labelledby="social-facebook"><title id="social-facebook">' . __( 'Facebook', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-facebook' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'facebook', __( 'Facebook', 'simple-social-icons' ) ),
 			),
 			'flickr' => array(
 				'label'   => __( 'Flickr URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-flickr"><a href="%s" %s><svg role="img" class="social-flickr" aria-labelledby="social-flickr"><title id="social-flickr">' . __( 'Flickr', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-flickr' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'flickr', __( 'Flickr', 'simple-social-icons' ) ),
 			),
 			'github' => array(
 				'label'   => __( 'GitHub URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-github"><a href="%s" %s><svg role="img" class="social-github" aria-labelledby="social-github"><title id="social-github">' . __( 'Github', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-github' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'github', __( 'GitHub', 'simple-social-icons' ) ),
 			),
 			'gplus' => array(
 				'label'   => __( 'Google+ URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-gplus"><a href="%s" %s><svg role="img" class="social-gplus" aria-labelledby="social-gplus"><title id="social-gplus">' . __( 'Google+', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-gplus' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'gplus', __( 'Google+', 'simple-social-icons' ) ),
 			),
 			'instagram' => array(
 				'label'   => __( 'Instagram URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-instagram"><a href="%s" %s><svg role="img" class="social-instagram" aria-labelledby="social-instagram"><title id="social-instagram">' . __( 'Instagram', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-instagram' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'instagram', __( 'Instagram', 'simple-social-icons' ) ),
 			),
 			'linkedin' => array(
 				'label'   => __( 'Linkedin URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-linkedin"><a href="%s" %s><svg role="img" class="social-linkedin" aria-labelledby="social-linkedin"><title id="social-linkedin">' . __( 'Linkedin', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-linkedin' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'linkedin', __( 'LinkedIn', 'simple-social-icons' ) ),
 			),
 			'medium' => array(
 				'label'   => __( 'Medium URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-medium"><a href="%s" %s><svg role="img" class="social-medium" aria-labelledby="social-medium"><title id="social-medium">' . __( 'Medium', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-medium' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'medium', __( 'Medium', 'simple-social-icons' ) ),
 			),
 			'periscope' => array(
 				'label'   => __( 'Periscope URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-periscope"><a href="%s" %s><svg role="img" class="social-periscope" aria-labelledby="social-periscope"><title id="social-periscope">' . __( 'Periscope', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-periscope' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'periscope', __( 'Periscope', 'simple-social-icons' ) ),
 			),
 			'phone' => array(
 				'label'   => __( 'Phone URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-phone"><a href="%s" %s><svg role="img" class="social-phone" aria-labelledby="social-phone"><title id="social-phone">' . __( 'Phone', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-phone' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'phone', __( 'Phone', 'simple-social-icons' ) ),
 			),
 			'pinterest' => array(
 				'label'   => __( 'Pinterest URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-pinterest"><a href="%s" %s><svg role="img" class="social-pinterest" aria-labelledby="social-pinterest"><title id="social-pinterest">' . __( 'Pinterest', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-pinterest' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'pinterest', __( 'Pinterest', 'simple-social-icons' ) ),
 			),
 			'rss' => array(
 				'label'   => __( 'RSS URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-rss"><a href="%s" %s><svg role="img" class="social-rss" aria-labelledby="social-rss"><title id="social-rss">' . __( 'RSS', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-rss' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'rss', __( 'RSS', 'simple-social-icons' ) ),
 			),
 			'snapchat' => array(
 				'label'   => __( 'Snapchat URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-snapchat"><a href="%s" %s><svg role="img" class="social-snapchat" aria-labelledby="social-snapchat"><title id="social-snapchat">' . __( 'Snapchat', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-snapchat' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'snapchat', __( 'Snapchat', 'simple-social-icons' ) ),
 			),
 			'stumbleupon' => array(
 				'label'   => __( 'StumbleUpon URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-stumbleupon"><a href="%s" %s><svg role="img" class="social-stumbleupon" aria-labelledby="social-stumbleupon"><title id="social-stumbleupon">' . __( 'StumbleUpon', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-stumbleupon' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'stumbleupon', __( 'StumbleUpon', 'simple-social-icons' ) ),
 			),
 			'tumblr' => array(
 				'label'   => __( 'Tumblr URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-tumblr"><a href="%s" %s><svg role="img" class="social-tumblr" aria-labelledby="social-tumblr"><title id="social-tumblr">' . __( 'Tumblr', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-tumblr' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'tumblr', __( 'Tumblr', 'simple-social-icons' ) ),
 			),
 			'twitter' => array(
 				'label'   => __( 'Twitter URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-twitter"><a href="%s" %s><svg role="img" class="social-twitter" aria-labelledby="social-twitter"><title id="social-twitter">' . __( 'Twitter', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-twitter' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'twitter', __( 'Twitter', 'simple-social-icons' ) ),
 			),
 			'vimeo' => array(
 				'label'   => __( 'Vimeo URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-vimeo"><a href="%s" %s><svg role="img" class="social-vimeo" aria-labelledby="social-vimeo"><title id="social-vimeo">' . __( 'Vimeo', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-vimeo' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'vimeo', __( 'Vimeo', 'simple-social-icons' ) ),
 			),
 			'xing' => array(
 				'label'   => __( 'Xing URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-xing"><a href="%s" %s><svg role="img" class="social-xing" aria-labelledby="social-xing"><title id="social-xing">' . __( 'Xing', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-xing' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'xing', __( 'xing', 'simple-social-icons' ) ),
 			),
 			'youtube' => array(
 				'label'   => __( 'YouTube URI', 'simple-social-icons' ),
-				'pattern' => '<li class="ssi-youtube"><a href="%s" %s><svg role="img" class="social-youtube" aria-labelledby="social-youtube"><title id="social-youtube">' . __( 'YouTube', 'simple-social-icons' ) . '</title><use xlink:href="' . esc_url( plugin_dir_url(__FILE__) . 'symbol-defs.svg#social-youtube' ) . '"></use></svg></a></li>',
+				'pattern' => $this->get_icon_markup( 'youtube', __( 'YouTube', 'simple-social-icons' ) ),
 			),
 		) );
 
@@ -398,8 +398,10 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 
 			}
 
-			if ( $output )
+			if ( $output ) {
+				$output = str_replace( '{WIDGET_INSTANCE_ID}', $this->number, $output );
 				printf( '<ul class="%s">%s</ul>', $instance['alignment'], $output );
+			}
 
 		echo $after_widget;
 
@@ -464,6 +466,25 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		echo '<style type="text/css" media="screen">' . $css . '</style>';
 
 	}
+
+	/**
+	 * Construct the markup for each icon
+	 *
+	 * @param string The lowercase icon name for use in tag attributes.
+	 * @param string The plain text icon label.
+	 *
+	 * @return string The full markup for the given icon.
+	 */
+	function get_icon_markup( $icon, $label ) {
+		$markup = '<li class="ssi-' . $icon . '"><a href="%s" %s>';
+		$markup .= '<svg role="img" class="social-' . $icon . '" aria-labelledby="social-' . $icon . '-{WIDGET_INSTANCE_ID}">';
+		$markup .= '<title id="social-' . $icon . '-{WIDGET_INSTANCE_ID}' . '">' . $label . '</title>';
+		$markup .= '<use xlink:href="' . esc_url( plugin_dir_url( __FILE__ ) . 'symbol-defs.svg#social-' . $icon ) . '"></use>';
+		$markup .= '</svg></a></li>';
+
+		return $markup;
+	}
+
 
 }
 


### PR DESCRIPTION
Ensures each icon title has a unique ID attribute by appending the
widget's instance ID. Fixes #43 to prevent ID conflicts when
multiple widgets are active.

Props @carasmo for reporting, @dreamwhisper for suggested fix.